### PR TITLE
crackxls2003: fix build on gcc-10 (-fno-common)

### DIFF
--- a/crackxls2003.c
+++ b/crackxls2003.c
@@ -44,30 +44,30 @@
 void convert_user_password(uint8_t real_key[5],
 	uint8_t *user_pass, int len, uint8_t salt[16]);
 
-const char *file_name;
-int flag_test_speed = 0;
-clock_t start_time, end_time;
+static const char *file_name;
+static int flag_test_speed = 0;
+static clock_t start_time, end_time;
 
 /* encrypted hash_and_verifier */
-uint8_t data[32];
+static uint8_t data[32];
 
 /* Password salt read from target document. */
-uint8_t password_salt[32];
+static uint8_t password_salt[32];
 /* we will take the md5 hash of the last 16 bytes */
 /* 80 = 16 + 16 + 48 */
-uint8_t hash_and_verifier[80];
+static uint8_t hash_and_verifier[80];
 
 /* First 5 bytes are the key space */
 /* 6th-9th bytes are 00 00 00 00 */
 /* md5 hash is taken of first 9 bytes */
 /* Full 64 bytes may be used in some implementation algorithms */
-uint32_t real_key[16];
+static uint32_t real_key[16];
 
 /* Used to calculate the total number of keys tested */
-uint32_t real_key_start[2];
+static uint32_t real_key_start[2];
 
 /* Whether we have a .doc or .xls file. */
-int is_doc;
+static int is_doc;
 
 void print_hex (uint8_t *array, int n);
 

--- a/decrypt.c
+++ b/decrypt.c
@@ -34,16 +34,16 @@
 
 #include <setjmp.h>
 
-GError    *err = NULL;
+static GError    *err = NULL;
 
-GsfInput *input_stream;
-GsfOutput *output_stream;
+static GsfInput *input_stream;
+static GsfOutput *output_stream;
 
 /* decryption variables */
-uint8_t rc4_key[16];
-RC4_KEY rc4_state;
-uint32_t block_number;
-int block_pos; /* Position within 1024-byte block */
+static uint8_t rc4_key[16];
+static RC4_KEY rc4_state;
+static uint32_t block_number;
+static int block_pos; /* Position within 1024-byte block */
 
 /* First 5 bytes are the found encryption key */
 /* Following 4 bytes are block number (little endian?) */
@@ -110,7 +110,7 @@ void dump_decrypt (int n, int suppress_decryption)
 	put (decrypted_bytes, n);
 }
 
-jmp_buf jmp_decryption_finished;
+static jmp_buf jmp_decryption_finished;
 
 void decrypt_record (void)
 {


### PR DESCRIPTION
gcc-10 changed the default from -fcommon to fno-common:
  https://gcc.gnu.org/PR85678

As a result build fails as:

  ld: decrypt.o:/build/crackxls2003/decrypt.c:50: multiple definition of
    `real_key'; crackxls2003.o:/build/crackxls2003/crackxls2003.c:64: first defined here

The change makes all global variables module-local to unshare accidental
`real_key` overlay.